### PR TITLE
fix: fixed module import paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,13 +20,13 @@
   },
   "version": "0.3.9",
   "type": "module",
-  "main": "./dist/payrexx-sdk.umd.cjs",
-  "module": "./dist/payrexx-sdk.js",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
   "types": "./dist/lib/index.d.ts",
   "exports": {
     ".": {
-      "import": "./dist/payrexx-sdk.js",
-      "require": "./dist/payrexx-sdk.umd.cjs"
+      "import": "./dist/index.js",
+      "require": "./dist/index.cjs"
     }
   },
   "files": [


### PR DESCRIPTION
# 📃 Short Description

Set correct file paths of fresh build output in `package.json`.

## 💻 Testing Notes

When importing the module installed via NPM, it threw a `Module not found` exception (at least within NextJS 14). After fixing this, it worked.

## 🚀 Issue Reference

fixes https://github.com/3AP-AG/payrexx-sdk/issues/38

## 🛂 Checks

~~- [ ] This PR follows the coding guidelines of the project~~ (could not find any)
- [x] This PR fulfilled the acceptance criteria defined on the issue
- [x] This PR has been locally tested
