### PR TITLE
expose types in bundler resolution mode too

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
   "exports": {
     ".": {
       "import": "./dist/index.js",
-      "require": "./dist/index.cjs"
+      "require": "./dist/index.cjs",
+      "types": "./dist/lib/index.d.ts"
     }
   },
   "files": [


### PR DESCRIPTION
# 📃 Short Description

- augment the `payrexx-sdk` package `exports` map so the existing `dist/lib/index.d.ts` file is surfaced when `moduleResolution: "bundler"` is used
- confirm that TypeScript now resolves `GatewayRequest` / `PayrexxClient`

## 💻 Testing Notes

- verified in IDE and using `tsc` that the imports now expose proper typings with bundler resolution

## 🚀 Issue Reference

fixes https://github.com/3AP-AG/payrexx-sdk/issues/43

## 🛂 Checks

- [X] This PR follows the coding guidelines of the project
- [X] This PR fulfilled the acceptance criteria defined on the issue
- [X] This PR has been locally tested