### PR TITLE
chore: update actions/checkout from v3 to v4

### DIFF
--- a/.github/workflows/npm-version.yml
+++ b/.github/workflows/npm-version.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.head_ref }}
           fetch-depth: '0'

--- a/.github/workflows/publish-npm-package.yml
+++ b/.github/workflows/publish-npm-package.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: '0'
           ref: ${{ github.event.release.tag_name }}

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     name: Check format and build
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
           node-version: 22


### PR DESCRIPTION
## Summary
- Updates `actions/checkout@v3` → `actions/checkout@v4` in all three workflow files:
  - `.github/workflows/npm-version.yml`
  - `.github/workflows/publish-npm-package.yml`
  - `.github/workflows/pull-request.yml`

Resolves DEVCO-535.

🤖 Generated with [Claude Code](https://claude.com/claude-code)